### PR TITLE
fix(tower_autoattack): Temporary fix for towers not autoatacking in 7.20E

### DIFF
--- a/game/dota_addons/element_td/scripts/vscripts/towers/modifier_attack_targeting.lua
+++ b/game/dota_addons/element_td/scripts/vscripts/towers/modifier_attack_targeting.lua
@@ -28,7 +28,17 @@ end
 function modifier_attack_targeting:OnIntervalThink()
     local unit = self:GetParent()
     if unit:HasModifier("modifier_disarmed") then return end
-    local findRadius = unit:GetAttackRange() + unit:GetHullRadius()
+    -- local findRadius = unit:GetAttackRange() + unit:GetHullRadius()
+    --[[ 
+        Changed from GetAttackRange to GetAcquisitionRange since the values are
+        essentially the same due to their properties.
+            - Essentially, Valve released something that broke GetAttackRange not
+            being available on specific occations, as to which I'll try to track down
+            though it probably boils down to `buildinghelper.lua`
+        This is only a temporary patch until Valve fixes 7.20E
+        Pleae revert as soon as this is fixed.
+    ]]-
+    local findRadius = unit:GetAcquisitionRange() + unit:GetHullRadius()
     local attackTarget = unit:GetAttackTarget()
 
     -- Stop focusing targets after leaking


### PR DESCRIPTION
## Issue
Since the latest patch, the `GetAttackRange()` method became missing on some specific towers. Specifically, the ones that use an attack_targeting modifier. This might be tracked down and patched more elegantly in `buildinghelper` but for now this will suffice.

## Fix
Changed the `findRadius` variable to use the tower's `AcquisitionRange` since that value and the `AttackRange` values are identical. The `findRadius` value can be also very forgiving since it's only used for calculating target acquisition.